### PR TITLE
Fix prefer-default-export rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
 
     'flowtype/no-types-missing-file-annotation': 0,
 
-    'import/prefer-default-export': 'none',
+    'import/prefer-default-export': 0,
 
     'import/no-extraneous-dependencies': [
       'error',


### PR DESCRIPTION
```
Configuration for rule "import/prefer-default-export" is invalid:
	Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"none"').
```